### PR TITLE
Delete deprecated params and add debezium base URL

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -35,7 +35,6 @@ spring:
       advanced:
         timestamp-generator:
           class: com.datastax.oss.driver.internal.core.time.ServerSideTimestampGenerator
-  kafka:
 
 # Common monitoring configuration
 management:

--- a/openframe-api-k8s.yml
+++ b/openframe-api-k8s.yml
@@ -1,15 +1,9 @@
 # API service docker environment configuration
 spring:
-  kafka:
-    bootstrap-servers: kafka.datasources.svc.cluster.local:9092
   oss-tenant:
     enabled: false
   saas:
     enabled: false
-#    kafka:
-#      bootstrap-servers: saas-kafka.datasources.svc.cluster.local:29094
-#      producer:
-#        client-id: oss-tenant-saas-producer
 
 oauth:
   client:

--- a/openframe-client-k8s.yml
+++ b/openframe-client-k8s.yml
@@ -1,6 +1,4 @@
 spring:
-  kafka:
-    bootstrap-servers: kafka.datasources.svc.cluster.local:9092
   oss-tenant:
     kafka:
       bootstrap-servers: kafka.datasources.svc.cluster.local:9092

--- a/openframe-client.yml
+++ b/openframe-client.yml
@@ -28,8 +28,6 @@ spring:
         min-idle: 0
         max-wait: 1000ms
     client-type: lettuce
-  kafka:
-    enabled: true
   oss-tenant:
     kafka:
       enabled: true
@@ -138,12 +136,7 @@ oauth:
         - client_credentials
       scopes:
         - agent
-kafka:
-  producer:
-    topic:
-      machine:
-        name: devices-topic
-
+      
 openframe:
   oss-tenant:
     kafka:

--- a/openframe-external-api.yml
+++ b/openframe-external-api.yml
@@ -13,8 +13,6 @@ spring:
       enabled: true
     redis:
       enabled: false
-  kafka:
-    enabled: false
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.cassandra.CassandraAutoConfiguration

--- a/openframe-management-k8s.yml
+++ b/openframe-management-k8s.yml
@@ -9,8 +9,5 @@ spring:
       host: redis-master.datasources.svc.cluster.local
       port: 6379
 
-  kafka:
-    bootstrap-servers: kafka.datasources.svc.cluster.local:9092
-
 management:
   key: ${OPENFRAME_MANAGEMENT_KEY:docker-management-key-123}

--- a/openframe-management.yml
+++ b/openframe-management.yml
@@ -8,8 +8,6 @@ spring:
       enabled: true
     cassandra:
       enabled: false
-  kafka:
-    enabled: false
   cloud:
     config:
       fail-fast: false
@@ -43,6 +41,9 @@ openframe:
       client-id: openframe-gateway
       client-secret: openframe-gateway-secret
       redirect-uri: https://localhost/oauth/callback
+      
+  debezium:
+    base-url: http://debezium-connect.datasources:8083
 
   integration:
     tool:

--- a/openframe-stream-k8s.yml
+++ b/openframe-stream-k8s.yml
@@ -1,12 +1,5 @@
 # Stream service docker environment configuration
 spring:
-  kafka:
-    bootstrap-servers: kafka.datasources.svc.cluster.local:9092
-    consumer:
-      group-id: openframe-stream-group
-      auto-offset-reset: earliest
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
   oss-tenant:
     kafka:

--- a/openframe-stream.yml
+++ b/openframe-stream.yml
@@ -22,18 +22,6 @@ spring:
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
   redis:
     enabled: true
-  kafka:
-    enabled: true
-    producer:
-      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-    consumer:
-      group-id: openframe-stream
-      auto-offset-reset: earliest
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-      properties:
-        spring.json.trusted.packages: "*"
   oss-tenant:
     enabled: true
     kafka:
@@ -48,25 +36,6 @@ spring:
   cloud:
     config:
       fail-fast: false
-kafka:
-  consumer:
-    topic:
-      event:
-        meshcentral:
-          name: meshcentral.mongodb.events
-        tactical-rmm:
-          name: tactical-rmm.postgres.events
-        fleet-mdm:
-          name: fleet.mysql.events
-      stream:
-        fleet-mdm:
-          activities: fleet.activities.events
-          host-activities: fleet.host_activities.events
-  producer:
-    topic:
-      it:
-        event:
-          name: integrated-tool.events.pinot
 # Fleet MDM Configuration
 fleet:
   mdm:


### PR DESCRIPTION
**Description**
Removed outdated and unused Kafka parameters from the `application.yml` configuration files across different services.  
Added a new parameter `openframe.debezium.base-url` to the **openframe-management** service.

**Improvements**
- Cleaned up `application.yml` by removing deprecated Kafka parameters
- Simplified service configuration by keeping only relevant and active settings
- Added `openframe.debezium.base-url` parameter to openframe-management service
